### PR TITLE
Fixed ordering

### DIFF
--- a/prototypes/entities/intermediates.lua
+++ b/prototypes/entities/intermediates.lua
@@ -498,3 +498,6 @@ data:extend({
 	]]--
 
 })
+
+data.raw["item-subgroup"]["science-pack"].group = "sct-science"
+data.raw["item-subgroup"]["science-pack"].order = "z"

--- a/prototypes/entities/intermediates.lua
+++ b/prototypes/entities/intermediates.lua
@@ -299,7 +299,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-prod-biosilicate.png",
 		flags = {"goes-to-main-inventory"},
 		subgroup = "sct-sciencepack-prod",
-		order = "b3[biosilicate]",
+		order = "b-a-c",
 		stack_size = 200
 	},
 
@@ -310,7 +310,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-prod-baked-biopaste.png",
 		flags = {"goes-to-main-inventory"},
 		subgroup = "sct-sciencepack-prod",
-		order = "b1[biopaste]",
+		order = "b-a-b",
 		stack_size = 200
 	},
 
@@ -321,7 +321,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/bioprocessor.png",
 		flags = {"goes-to-main-inventory"},
 		subgroup = "sct-sciencepack-prod",
-		order = "b1[bioprocessor]",
+		order = "b-a-a",
 		stack_size = 200
 	},
 
@@ -332,7 +332,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/overclocker.png",
 		flags = {"goes-to-main-inventory"},
 		subgroup = "sct-sciencepack-prod",
-		order = "b4[overclocker]",
+		order = "b-b",
 		stack_size = 200
 	},
 

--- a/prototypes/entities/sciencepacks.lua
+++ b/prototypes/entities/sciencepacks.lua
@@ -1,16 +1,19 @@
 -- since this overriding existing item, we only alter grouping here, recipe changes are in recipe
 
-data.raw["tool"]["science-pack-2"].subgroup = "sct-sciencepack-2"
-data.raw["tool"]["science-pack-2"].order = "a[science-pack-2]"
+data.raw["tool"]["science-pack-2"].subgroup = "science-pack"
+data.raw["tool"]["science-pack-2"].order = "a[science-pack-1]"
 
-data.raw["tool"]["science-pack-3"].subgroup = "sct-sciencepack-3"
-data.raw["tool"]["science-pack-3"].order = "a[science-pack-3]"
+data.raw["tool"]["science-pack-2"].subgroup = "science-pack"
+data.raw["tool"]["science-pack-2"].order = "b[science-pack-2]"
 
-data.raw["tool"]["military-science-pack"].subgroup = "sct-sciencepack-mil"
-data.raw["tool"]["military-science-pack"].order = "a[military-science-pack]"
+data.raw["tool"]["science-pack-3"].subgroup = "science-pack"
+data.raw["tool"]["science-pack-3"].order = "c[science-pack-3]"
 
-data.raw["tool"]["production-science-pack"].subgroup = "sct-sciencepack-prod"
-data.raw["tool"]["production-science-pack"].order = "a[production-science-pack]"
+data.raw["tool"]["military-science-pack"].subgroup = "science-pack"
+data.raw["tool"]["military-science-pack"].order = "d[military-science-pack]"
 
-data.raw["tool"]["high-tech-science-pack"].subgroup = "sct-sciencepack-hightech"
-data.raw["tool"]["high-tech-science-pack"].order = "a[high-tech-science-pack]"
+data.raw["tool"]["production-science-pack"].subgroup = "science-pack"
+data.raw["tool"]["production-science-pack"].order = "e-c-a"
+
+data.raw["tool"]["high-tech-science-pack"].subgroup = "science-pack"
+data.raw["tool"]["high-tech-science-pack"].order = "f-b"

--- a/prototypes/recipes/sciencepacks.lua
+++ b/prototypes/recipes/sciencepacks.lua
@@ -125,3 +125,4 @@ data.raw["recipe"]["high-tech-science-pack"].ingredients =
 		{"sct-htech-random", 1}
     }
 data.raw["recipe"]["high-tech-science-pack"].subgroup = "sct-sciencepack-hightech"
+data.raw["recipe"]["high-tech-science-pack"].order = "a[high-tech-science-pack]"

--- a/tweaks/angelsmods/2_final.lua
+++ b/tweaks/angelsmods/2_final.lua
@@ -9,7 +9,7 @@ if mods["angelsbioprocessing"] then
 		table.insert(data.raw["lab"]["sct-lab-3"].inputs, "token-bio")
 		table.insert(data.raw["lab"]["sct-lab-4"].inputs, "token-bio")
 
-    data.raw.tool["token-bio"].order = "b[token-bio]"
-    data.raw.tool["token-bio"].subgroup = "science-pack"
+		data.raw.tool["token-bio"].order = "b[token-bio]"
+		data.raw.tool["token-bio"].subgroup = "science-pack"
 	end
 end

--- a/tweaks/angelsmods/2_final.lua
+++ b/tweaks/angelsmods/2_final.lua
@@ -8,5 +8,8 @@ if mods["angelsbioprocessing"] then
 		table.insert(data.raw["lab"]["sct-lab-2"].inputs, "token-bio")
 		table.insert(data.raw["lab"]["sct-lab-3"].inputs, "token-bio")
 		table.insert(data.raw["lab"]["sct-lab-4"].inputs, "token-bio")
+
+    data.raw.tool["token-bio"].order = "b[token-bio]"
+    data.raw.tool["token-bio"].subgroup = "science-pack"
 	end
 end

--- a/tweaks/bobsmods/2_final.lua
+++ b/tweaks/bobsmods/2_final.lua
@@ -24,16 +24,16 @@ require("tweaks.bobsmods.sciencegroup")
 		data.raw.tool["logistic-science-pack"].subgroup = "science-pack"
 		data.raw.tool["logistic-science-pack"].order = "e-c-b"
 	end
-  if data.raw.recipe["logistic-science-pack"] then
-  	data.raw.recipe["logistic-science-pack"].subgroup = "sct-sciencepack-logistic"
-  end
+	if data.raw.recipe["logistic-science-pack"] then
+		data.raw.recipe["logistic-science-pack"].subgroup = "sct-sciencepack-logistic"
+	end
 	if data.raw.tool["science-pack-gold"] then
 		data.raw.tool["science-pack-gold"].subgroup = "science-pack"
 		data.raw.tool["science-pack-gold"].order = "e-b-a"
 	end
-  if data.raw.recipe["science-pack-gold"] then
-  	data.raw.recipe["science-pack-gold"].subgroup = "sct-sciencepack-gold"
-  end
+	if data.raw.recipe["science-pack-gold"] then
+		data.raw.recipe["science-pack-gold"].subgroup = "sct-sciencepack-gold"
+	end
 	if data.raw.recipe["alien-science-pack"] and data.raw.tool["alien-science-pack"] then
 		data.raw.recipe["alien-science-pack"].subgroup = "sct-sciencepack-alien"
 		data.raw.recipe["alien-science-pack-blue"].subgroup = "sct-sciencepack-alien"
@@ -42,7 +42,7 @@ require("tweaks.bobsmods.sciencegroup")
 		data.raw.recipe["alien-science-pack-yellow"].subgroup = "sct-sciencepack-alien"
 		data.raw.recipe["alien-science-pack-green"].subgroup = "sct-sciencepack-alien"
 		data.raw.recipe["alien-science-pack-red"].subgroup = "sct-sciencepack-alien"
-    data.raw.tool["alien-science-pack"].order = "e-b-b"
+		data.raw.tool["alien-science-pack"].order = "e-b-b"
 		data.raw.tool["alien-science-pack-blue"].order = "e-b-c"
 		data.raw.tool["alien-science-pack-orange"].order = "e-b-d"
 		data.raw.tool["alien-science-pack-purple"].order = "e-b-e"

--- a/tweaks/bobsmods/2_final.lua
+++ b/tweaks/bobsmods/2_final.lua
@@ -21,21 +21,34 @@ require("tweaks.bobsmods.sciencegroup")
 		data.raw.item["lab-alien"].order = "e[lab5]"
 	end
 	if data.raw.tool["logistic-science-pack"] then
-		data.raw.tool["logistic-science-pack"].subgroup = "sct-sciencepack-logistic"
-		data.raw.tool["logistic-science-pack"].order = "a[logistic-science-pack]"
+		data.raw.tool["logistic-science-pack"].subgroup = "science-pack"
+		data.raw.tool["logistic-science-pack"].order = "e-c-b"
 	end
+  if data.raw.recipe["logistic-science-pack"] then
+  	data.raw.recipe["logistic-science-pack"].subgroup = "sct-sciencepack-logistic"
+  end
 	if data.raw.tool["science-pack-gold"] then
-		data.raw.tool["science-pack-gold"].subgroup = "sct-sciencepack-gold"
-		data.raw.tool["science-pack-gold"].order = "a[gold-science-pack]"
+		data.raw.tool["science-pack-gold"].subgroup = "science-pack"
+		data.raw.tool["science-pack-gold"].order = "e-b-a"
 	end
-	if data.raw.tool["alien-science-pack"] then
-		data.raw.tool["alien-science-pack"].subgroup = "sct-sciencepack-alien"
-		data.raw.tool["alien-science-pack-blue"].subgroup = "sct-sciencepack-alien"
-		data.raw.tool["alien-science-pack-orange"].subgroup = "sct-sciencepack-alien"
-		data.raw.tool["alien-science-pack-purple"].subgroup = "sct-sciencepack-alien"
-		data.raw.tool["alien-science-pack-yellow"].subgroup = "sct-sciencepack-alien"
-		data.raw.tool["alien-science-pack-green"].subgroup = "sct-sciencepack-alien"
-		data.raw.tool["alien-science-pack-red"].subgroup = "sct-sciencepack-alien"
+  if data.raw.recipe["science-pack-gold"] then
+  	data.raw.recipe["science-pack-gold"].subgroup = "sct-sciencepack-gold"
+  end
+	if data.raw.recipe["alien-science-pack"] and data.raw.tool["alien-science-pack"] then
+		data.raw.recipe["alien-science-pack"].subgroup = "sct-sciencepack-alien"
+		data.raw.recipe["alien-science-pack-blue"].subgroup = "sct-sciencepack-alien"
+		data.raw.recipe["alien-science-pack-orange"].subgroup = "sct-sciencepack-alien"
+		data.raw.recipe["alien-science-pack-purple"].subgroup = "sct-sciencepack-alien"
+		data.raw.recipe["alien-science-pack-yellow"].subgroup = "sct-sciencepack-alien"
+		data.raw.recipe["alien-science-pack-green"].subgroup = "sct-sciencepack-alien"
+		data.raw.recipe["alien-science-pack-red"].subgroup = "sct-sciencepack-alien"
+    data.raw.tool["alien-science-pack"].order = "e-b-b"
+		data.raw.tool["alien-science-pack-blue"].order = "e-b-c"
+		data.raw.tool["alien-science-pack-orange"].order = "e-b-d"
+		data.raw.tool["alien-science-pack-purple"].order = "e-b-e"
+		data.raw.tool["alien-science-pack-yellow"].order = "e-b-f"
+		data.raw.tool["alien-science-pack-green"].order = "e-b-g"
+		data.raw.tool["alien-science-pack-red"].order = "e-b-h"
 	end
 end
 

--- a/tweaks/vanilla/0_initial.lua
+++ b/tweaks/vanilla/0_initial.lua
@@ -61,7 +61,7 @@ data:extend({
 		type = "recipe",
 		name = "sct-t2-reaction-nodes",
 		subgroup = "sct-sciencepack-2",
-		order = "b[reactionnodes]",
+		order = "b-b",
 		enabled = "true",
 		energy_required = 1.5,
 		ingredients =
@@ -79,7 +79,7 @@ data:extend({
 		type = "recipe",
 		name = "sct-t2-instruments",
 		subgroup = "sct-sciencepack-2",
-		order = "b[instruments]",
+		order = "b-a-a",
 		enabled = "true",
 		energy_required = 1.5,
 		ingredients =
@@ -97,7 +97,7 @@ data:extend({
 		type = "recipe",
 		name = "sct-t2-microcircuits",
 		subgroup = "sct-sciencepack-2",
-		order = "b[microcircuits]",
+		order = "b-a-b",
 		enabled = "true",
 		energy_required = 1.5,
 		ingredients =
@@ -115,7 +115,7 @@ data:extend({
 		type = "recipe",
 		name = "sct-t2-micro-wafer",
 		subgroup = "sct-sciencepack-2",
-		order = "b[microwafer]",
+		order = "b-a-c",
 		enabled = "true",
 		energy_required = 3,
 		ingredients =
@@ -133,7 +133,7 @@ data:extend({
 		type = "recipe",
 		name = "sct-t2-wafer-stamp",
 		subgroup = "sct-sciencepack-2",
-		order = "b[waferstamp]",
+		order = "b-a-d",
 		enabled = "true",
 		energy_required = 3,
 		ingredients =
@@ -155,7 +155,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/flash-fuel.png",
 		subgroup = "sct-sciencepack-3",
-		order = "b[flashfuel]",
+		order = "b-b",
 		enabled = "false",
 		energy_required = 3,
 		ingredients =
@@ -177,7 +177,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/laser-foci.png",
 		subgroup = "sct-sciencepack-3",
-		order = "b[laserfoci]",
+		order = "b-c",
 		enabled = "false",
 		energy_required = 3,
 		ingredients =
@@ -198,7 +198,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/laser-emitter.png",
 		subgroup = "sct-sciencepack-3",
-		order = "b[laseremitter]",
+		order = "b-d",
 		category = "crafting",
 		enabled = "false",
 		energy_required = 3,
@@ -222,7 +222,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/femto-lasers.png",
 		subgroup = "sct-sciencepack-3",
-		order = "b[femtolasers]",
+		order = "b-a",
 		enabled = "false",
 		energy_required = 3,
 		ingredients =
@@ -244,7 +244,7 @@ data:extend({
 		category = "crafting-with-fluid",
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/atomic-sensors.png",
-		order = "b[atomicsensors]",
+		order = "b-e",
 		subgroup = "sct-sciencepack-3",
 		enabled = "false",
 		energy_required = 3,
@@ -271,7 +271,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-mil-subplating.png",
 		category = "crafting",
 		subgroup = "sct-sciencepack-mil",
-		order = "b[subplating]",
+		order = "b-a-b",
 		enabled = "false",
 		energy_required = 0.5,
 		ingredients =
@@ -292,7 +292,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-mil-plating.png",
 		category = "advanced-crafting",
 		subgroup = "sct-sciencepack-mil",
-		order = "b[plating]",
+		order = "b-a-a",
 		enabled = "false",
 		energy_required = 10,
 		ingredients =
@@ -315,7 +315,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/military_analysis_1.png",
 		category = "crafting",
 		subgroup = "sct-sciencepack-mil",
-		order = "b[circuit1]",
+		order = "b-b-c",
 		enabled = "false",
 		energy_required = 1,
 		ingredients =
@@ -337,7 +337,7 @@ data:extend({
 		icon = "__ScienceCostTweakerM__/graphics/icons/military_analysis_2.png",
 		category = "crafting",
 		subgroup = "sct-sciencepack-mil",
-		order = "b[circuit2]",
+		order = "b-b-b",
 		enabled = "false",
 		energy_required = 1,
 		ingredients =
@@ -359,7 +359,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/military_analysis_3.png",
 		subgroup = "sct-sciencepack-mil",
-		order = "b[circuit3]",
+		order = "b-b-a",
 		enabled = "false",
 		energy_required = 1,
 		ingredients =
@@ -387,7 +387,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-prod-biosilicate.png",
 		subgroup = "sct-sciencepack-prod",
-		order = "b[biosillicate]",
+		order = "b-a-c",
 		enabled = "false",
 		energy_required = 3,
 		ingredients =
@@ -409,7 +409,7 @@ data:extend({
 		name = "sct-prod-baked-biopaste",
 		category = "smelting",
 		subgroup = "sct-sciencepack-prod",
-		order = "b[biopaste]",
+		order = "b-a-b",
 		energy_required = 3,
 		enabled = "false",
 		ingredients = {{"sct-prod-biosilicate", 1}},
@@ -423,7 +423,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/bioprocessor.png",
 		subgroup = "sct-sciencepack-prod",
-		order = "b[bioprocessor]",
+		order = "b-a-a",
 		enabled = "false",
 		energy_required = 30,
 		ingredients =
@@ -445,7 +445,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/overclocker.png",
 		subgroup = "sct-sciencepack-prod",
-		order = "b[overclocker]",
+		order = "b-b",
 		enabled = "false",
 		energy_required = 1,
 		ingredients =
@@ -474,7 +474,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-htech-capbank.png",
 		subgroup = "sct-sciencepack-hightech",
-		order = "b[capbank]",
+		order = "b-a",
 		enabled = "false",
 		energy_required = 4,
 		ingredients =
@@ -497,7 +497,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-htech-injector.png",
 		subgroup = "sct-sciencepack-hightech",
-		order = "b[capbank]",
+		order = "b-b",
 		enabled = "false",
 		energy_required = 3.5,
 		ingredients =
@@ -521,7 +521,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-htech-thermalstore.png",
 		subgroup = "sct-sciencepack-hightech",
-		order = "b[thermalstore]",
+		order = "b-c-d",
 		enabled = "false",
 		energy_required = 3.5,
 		ingredients =
@@ -540,7 +540,7 @@ data:extend({
 		name = "sct-htech-thermalstore-heated",
 		category = "smelting",
 		subgroup = "sct-sciencepack-hightech",
-		order = "b[heatedthermalstore]",
+		order = "b-c-b",
 		energy_required = 22,
 		enabled = "false",
 		ingredients = {{"sct-htech-thermalstore", 1}},
@@ -554,7 +554,7 @@ data:extend({
 		icon_size = 32,
 		icon = "__ScienceCostTweakerM__/graphics/icons/sct-htech-random.png",
 		subgroup = "sct-sciencepack-hightech",
-		order = "b[random]",
+		order = "b-c-a",
 		enabled = "false",
 		energy_required = 7,
 		ingredients =


### PR DESCRIPTION
Disclaimer: I tested with the seablock pack.

This fixes the following things:
* Wrong order of techs in tech window [Before](https://i.imgur.com/HvkJum3.png) -> [After](https://i.imgur.com/Bg5UOmw.png)
* Wrong order within the recipe subgroups and the items [Before](https://i.imgur.com/DgVtcjR.png) -> [After](https://i.imgur.com/nmoMESR.png)
* The science packs used to be split between two groups in the signal selection, now they in a subgroup in the sct group [After](https://i.imgur.com/WNEpP6w.png)

The first and last change are achieved by putting all science **items** into the same subgroup, otherwise the tech screen does not sort correctly. I recommend keeping all science items in the same group for this reason. The second change mostly affects recipes since the item order was already correct.

For anybody who does not know how order works, the wiki has a [page](https://wiki.factorio.com/Types/Order) on it. In short: Order strings are **simple strings** that are sorted in ASCII-order. So, there is no need to include the prototype name or anything ``[like-this]`` in the order string.