### PR TITLE
Keep requisite on automation-2

### DIFF
--- a/prototypes/technologies/sciencepacks.lua
+++ b/prototypes/technologies/sciencepacks.lua
@@ -74,6 +74,7 @@ data:extend({
 		},
 		prerequisites =
 		{
+			"automation-2",
 			"sct-lab-t2",
 		},
 		unit =


### PR DESCRIPTION
While updating to 0.17 I saw automation-2 caused problems. But with bob renaming logistic-sciences-packs to advanced-logistic-science-packs that went away.

So I wonder why you removed the prerequisite on automation-2. Did you run into the same loop but didn't notice it went away later?

