### PR TITLE
Add API for ignoring technologies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.17.11
+Date: 14. 6. 2019
+  Changes:
+    - Added 'NormalNoCheapStart' setting that doesn't cut red science in half
+    - Added MOD API config ('SCTTweaks.ignore_techs') to set technologies that shouldn't be impacted (Ex, SpaceMod). 
+---------------------------------------------------------------------------------------------------
 Version: 0.17.10
 Date: 27. 5. 2019
   Changes:

--- a/configs/costs/normalnocheapstart.lua
+++ b/configs/costs/normalnocheapstart.lua
@@ -1,0 +1,18 @@
+require("configs.costs.rawmodels")
+
+if not sct_cost then sct_cost = {} end
+if not sct_cost.normalnocheapstart then sct_cost.normalnocheapstart = {} end
+if not sct_cost.normalnocheapstart.costs then sct_cost.normalnocheapstart.costs = {} end
+
+-- =================================================================================================================================================================== --
+-- Cost Adjustments for the various tiers of research.
+-- =================================================================================================================================================================== --
+-- SCT_newTier(timeMult, stepCountMult, redMult, greenMult, blueMult, militaryMult, productionMult, hightechMult)
+sct_cost.normalnocheapstart.costs.tier1 = SCT_newTier(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- Half the cost
+sct_cost.normalnocheapstart.costs.tier2 = SCT_newTier(1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- 2x overall more expensive
+sct_cost.normalnocheapstart.costs.military = SCT_newTier(1.0, 4.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- 4x overall more expensive
+sct_cost.normalnocheapstart.costs.production = SCT_newTier(1.0, 4.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- 4x overall more expensive
+sct_cost.normalnocheapstart.costs.tier3 = SCT_newTier(1.0, 6.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- 6x overall more expensive
+sct_cost.normalnocheapstart.costs.hightech = SCT_newTier(1.0, 8.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- 8x overall more expensive
+sct_cost.normalnocheapstart.costs.bobmodules = SCT_newBobModules(1.0, 8.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) -- 8x overall more expensive
+sct_cost.normalnocheapstart.costs.formula = SCT_formulaMod(1.0, "(", ")") -- No change

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -3,6 +3,7 @@ require("config")
 require("configs.costs.lolwhat")
 require("configs.costs.uberwaffe")
 require("configs.costs.normal")
+require("configs.costs.normalnocheapstart")
 require("configs.costs.extended")
 -- Recipe fixes
 require("prototypes.2_recipe")
@@ -25,38 +26,43 @@ if (settings.startup["sct-difficulty-cost"].value ~= "noadjustment") then
 
 	-- Iterate through all research, and update the costs as configured.
 	for index,tech in pairs(data.raw.technology) do 
-		-- First, determine the tier of the research, by looking at what types of science packs is used in its research cost.
+		-- First, see if we should ignore this technology
+		multiplier = nil
 
-		tier = 1
-		multiplier = sciencecosttweaker.costs.tier1;
-		for Index, Value in pairs( tech.unit.ingredients ) do
-			if (tier < 2 and tech.unit.ingredients[Index][1] == "logistic-science-pack") then
-				tier = 2
-				multiplier = sciencecosttweaker.costs.tier2;
-			end
-			if (tier < 3 and tech.unit.ingredients[Index][1] == "military-science-pack") then
-				tier = 3
-				multiplier = sciencecosttweaker.costs.military;
-			end
-			if (tier < 4 and tech.unit.ingredients[Index][1] == "production-science-pack") then
-				tier = 4
-				multiplier = sciencecosttweaker.costs.production;
-			end
-			if (tier < 5 and tech.unit.ingredients[Index][1] == "chemical-science-pack") then
-				tier = 5
-				multiplier = sciencecosttweaker.costs.tier3;
-			end
-			if (tier < 6 and tech.unit.ingredients[Index][1] == "utility-science-pack") then
-				tier = 6
-				multiplier = sciencecosttweaker.costs.hightech;
-			end
-			if (tier < 99 and tech.unit.ingredients[Index][1] == "module-case") then
-				tier = 99
-				multiplier = sciencecosttweaker.costs.bobmodules;
-			end
-			if (tech.unit.count_formula ~= nil) then
-				tier = 999999
-				multiplier = sciencecosttweaker.costs.formula;
+		if not sct.api.ignore_techs[tech.name] then
+			-- Second, determine the tier of the research, by looking at what types of science packs is used in its research cost.
+
+			tier = 1
+			multiplier = sciencecosttweaker.costs.tier1;
+			for Index, Value in pairs( tech.unit.ingredients ) do
+				if (tier < 2 and tech.unit.ingredients[Index][1] == "logistic-science-pack") then
+					tier = 2
+					multiplier = sciencecosttweaker.costs.tier2;
+				end
+				if (tier < 3 and tech.unit.ingredients[Index][1] == "military-science-pack") then
+					tier = 3
+					multiplier = sciencecosttweaker.costs.military;
+				end
+				if (tier < 4 and tech.unit.ingredients[Index][1] == "production-science-pack") then
+					tier = 4
+					multiplier = sciencecosttweaker.costs.production;
+				end
+				if (tier < 5 and tech.unit.ingredients[Index][1] == "chemical-science-pack") then
+					tier = 5
+					multiplier = sciencecosttweaker.costs.tier3;
+				end
+				if (tier < 6 and tech.unit.ingredients[Index][1] == "utility-science-pack") then
+					tier = 6
+					multiplier = sciencecosttweaker.costs.hightech;
+				end
+				if (tier < 99 and tech.unit.ingredients[Index][1] == "module-case") then
+					tier = 99
+					multiplier = sciencecosttweaker.costs.bobmodules;
+				end
+				if (tech.unit.count_formula ~= nil) then
+					tier = 999999
+					multiplier = sciencecosttweaker.costs.formula;
+				end
 			end
 		end
 

--- a/data.lua
+++ b/data.lua
@@ -1,5 +1,8 @@
 --INITIALIZE
 if not SCTTweaks then SCTTweaks = {} end
+if not sct then sct = {} end
+if not sct.api then sct.api = {} end
+if not sct.api.ignore_techs then sct.api.ignore_techs = {} end
 
 require("sctmlib")
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "ScienceCostTweakerM",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "factorio_version":"0.17",
   "title": "ScienceCostTweaker Mod (mexmer)",
   "author": "mexmer",

--- a/locale/en/sciencecosttweaker.cfg
+++ b/locale/en/sciencecosttweaker.cfg
@@ -8,7 +8,7 @@ sct-tier1-lab=Tier 1 lab prototype
 sct-lab-modules=Allow modules in labs
 sct-connect-science=Connect science packs
 [mod-setting-description]
-sct-difficulty-cost=Applies multipliers to the cost of technology, based on what "Tier" of science it is.\n\nlolwhat : Everything x0.01.\nUberWaffe : Mil x2, Prod x2, High x5.\nNormal : T2 x2, T3 x4, Mil x4, Prod x4, High x6.\nExtended : T2 x4, T3 x6, Mil x10, Prod x10, High x20, Inf x25.
+sct-difficulty-cost=Applies multipliers to the cost of technology, based on what "Tier" of science it is.\n\nlolwhat : Everything x0.01.\nUberWaffe : Mil x2, Prod x2, High x5.\nNormal :T1 1/2, T2 x2, T3 x4, Mil x4, Prod x4, High x6.\nNormalNoCheapStart :T1 x1, T2 x2, T3 x4, Mil x4, Prod x4, High x6.\nExtended : T2 x4, T3 x6, Mil x10, Prod x10, High x20, Inf x25.
 sct-military=Determines when military research is available.\n\ntier2 : Default, available from tier 2 lab (green,red,military)\ntier3 : Available from tier 3 lab (all except space, hightech)
 sct-bio=Determines when angels bio token research is available.\n\ntier1 : Available from tier 1 lab (red,bio)\ntier2 : Default, available from tier 2 lab (read, green, bio)
 sct-lab-scaling=Enables scaling of lab base research speed depending on lab tier\nlab 1 - speed 1, lab 2 - speed 1.1, lab 3 - speed 1.3, lab 4 - speed 1.5 (speed is still affected by research speed technonology).

--- a/settings.lua
+++ b/settings.lua
@@ -5,7 +5,7 @@ data:extend({
 		order = "sct-a[difficulty]",
 		setting_type = "startup",
 		default_value = "noadjustment",
-		allowed_values =  {"lolwhat", "noadjustment", "uberwaffe", "normal", "extended"}
+		allowed_values =  {"lolwhat", "noadjustment", "uberwaffe", "normal", "normalnocheapstart", "extended"}
 	},
 
 	{


### PR DESCRIPTION
- Add API to allow mods to declare technologies for SCT to ignore.*
- Add NormalNoCheapStart settings that don't use the 1/2 cost red science from the Normal settings.

*Used to avoid SpaceMod costs going even crazier when including both in my modpack