### PR TITLE
added check for tech costs having name property in unit ingredients

### DIFF
--- a/prototypes/2_technology.lua
+++ b/prototypes/2_technology.lua
@@ -85,7 +85,12 @@ function connect_sciencepack(sciencepackmap, first_science)
 			if _obj.unit.ingredients and table_size(_obj.unit.ingredients) > 0 then
 				local packlist = {} 
 				for _packid, _packobj in pairs(_obj.unit.ingredients) do
-					local packname = _packobj[1];
+					local packname 
+						if _packobj.name == nil then
+							packname = _packobj[1]
+						else
+							packname = _packobj.name
+						end
 					packlist[packname] = 0
 				end
 				if _obj.prerequisites and  table_size(_obj.prerequisites) > 0 then


### PR DESCRIPTION
with a recent change in angels mods that has the ingredients in in techs listed as long form with type and name properties it causes an error in sct as sct assumes tech ingredients are in the short form with just a name and number 