### PR TITLE
Hide extra Flash Fuel recipe

### DIFF
--- a/prototypes/1_recipe.lua
+++ b/prototypes/1_recipe.lua
@@ -1,7 +1,7 @@
 if data.raw.fluid["heavy-oil"] and data.raw.fluid["light-oil"] then
-    data.raw.recipe["sct-t3-flash-fuel"].hidden = false
+    sctm.hide_recipe("sct-t3-flash-fuel2")
     sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel")
 else
-    data.raw.recipe["sct-t3-flash-fuel2"].hidden = false
+    sctm.hide_recipe("sct-t3-flash-fuel")
     sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
 end

--- a/prototypes/recipes/sciencepacks-intermediates.lua
+++ b/prototypes/recipes/sciencepacks-intermediates.lua
@@ -463,7 +463,6 @@ data:extend({
 		always_show_made_in = true,
 		subgroup = "sct-sciencepack-3",
 		order = "f[t3]-c[flashfuel]",
-		hidden = true,
 		expensive =
 		{
 			enabled = false,
@@ -503,7 +502,6 @@ data:extend({
 		always_show_made_in = true,
 		subgroup = "sct-sciencepack-3",
 		order = "f[t3]-c[flashfuel2]",
-		hidden = true,
 		expensive =
 		{
 			enabled = false,


### PR DESCRIPTION
Extra flash fuel recipe doesn't have a tech unlock (correct) but isn't marked as hidden (incorrect).

This fix is low importance so I wouldn't bother putting out a release just for this.