### PR TITLE
Fix softlock at blue science (Issue #79)

### DIFF
--- a/prototypes/1_recipe.lua
+++ b/prototypes/1_recipe.lua
@@ -1,7 +1,7 @@
+sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
+
 if data.raw.fluid["heavy-oil"] and data.raw.fluid["light-oil"] then
-    sctm.hide_recipe("sct-t3-flash-fuel2")
     sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel")
 else
     sctm.hide_recipe("sct-t3-flash-fuel")
-    sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
 end

--- a/prototypes/1_recipe.lua
+++ b/prototypes/1_recipe.lua
@@ -1,7 +1,7 @@
+sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
+
 if data.raw.fluid["heavy-oil"] and data.raw.fluid["light-oil"] then
-    sctm.hide_recipe("sct-t3-flash-fuel-2")
     sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel")
 else
     sctm.hide_recipe("sct-t3-flash-fuel")
-    sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
 end

--- a/prototypes/1_recipe.lua
+++ b/prototypes/1_recipe.lua
@@ -1,7 +1,7 @@
-sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
-
 if data.raw.fluid["heavy-oil"] and data.raw.fluid["light-oil"] then
+    sctm.hide_recipe("sct-t3-flash-fuel-2")
     sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel")
 else
     sctm.hide_recipe("sct-t3-flash-fuel")
+    sctm.tech_unlock_add("sct-lab-t3", "sct-t3-flash-fuel2")
 end


### PR DESCRIPTION
Flash fuel is uncraftable because of a softlock at chemical science. This would add the craftable flash fuel recipe to fix the softlock.