### PR TITLE
Show made_in machine for "tweaked" science packs

### DIFF
--- a/tweaks/aai/science_aai.lua
+++ b/tweaks/aai/science_aai.lua
@@ -133,6 +133,7 @@ if mods["aai-industry"] then
       expensive = 
       {
         enabled = true,
+        always_show_made_in = true,
         energy_required = 3,
         ingredients = 
         {
@@ -147,6 +148,7 @@ if mods["aai-industry"] then
       normal =
       {
         enabled = true,
+        always_show_made_in = true,
         energy_required = 3,
         ingredients = 
         {

--- a/tweaks/angelsmods/science_angels.lua
+++ b/tweaks/angelsmods/science_angels.lua
@@ -66,6 +66,7 @@ if mods["angelsbioprocessing"] then
       expensive =
       {
         enabled = false,
+        always_show_made_in = true,
         energy_required = 5,
         ingredients =
         {
@@ -80,6 +81,7 @@ if mods["angelsbioprocessing"] then
       normal =
       {
         enabled = false,
+        always_show_made_in = true,
         energy_required = 5,
         ingredients =
         {

--- a/tweaks/bobsmods/science_bobmods_logistic.lua
+++ b/tweaks/bobsmods/science_bobmods_logistic.lua
@@ -137,6 +137,7 @@ if mods["bobtech"] then
       expensive = 
       {
         enabled = false,
+        always_show_made_in = true,
         energy_required = 14,
         ingredients = 
         {
@@ -151,6 +152,7 @@ if mods["bobtech"] then
       normal = 
       {
         enabled = false,
+        always_show_made_in = true,
         energy_required = 14,
         ingredients = 
         {


### PR DESCRIPTION
Tweaked science packs for various mods didn't always show the assembler the pack could be made in.  The generic packs did.  This arbitrarily standardizes on always showing them.  

I think it's just as valid to never show them, but this seems to be the intended approach of the mod?